### PR TITLE
Fix/typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To report user reviews, use the `report()` function.
 
 - `data` {array} review data (Required)
 - `options` {object} optional object
-  - `sepalator` {string} break word string like `\n` and `<br>`
+  - `separator` {string} break word string like `\n` and `<br>`
   - `day` {string} day string added to header
   - `template.header` {string} template string
   - `template.entry` {string} template string
@@ -78,8 +78,8 @@ You can customize the template.
 iTunesAppReviews.on('data', function(review) {
   var options = {
     template: {
-      header: '{title} total: {summary.total}{sepalator}',
-      entry: '{entry.rating.icon} by {entry.author}{sepalator}'
+      header: '{title} total: {summary.total}{separator}',
+      entry: '{entry.rating.icon} by {entry.author}{separator}'
     }
   };
   console.log(iTunesAppReviews.report(review, options));
@@ -95,10 +95,10 @@ iTunes Review Report total: 50
 #### header
 Default template:
 ```
-{title} {day}{sepalator}
-total:{summary.total} avg:{summary.average}{sepalator}
-{icon.s1} {summary.rating.s1} {icon.s2} {summary.rating.s2} {icon.s3} {summary.rating.s3} {icon.s4} {summary.rating.s4} {icon.s5} {summary.rating.s5}{sepalator}
-{sepalator}
+{title} {day}{separator}
+total:{summary.total} avg:{summary.average}{separator}
+{icon.s1} {summary.rating.s1} {icon.s2} {summary.rating.s2} {icon.s3} {summary.rating.s3} {icon.s4} {summary.rating.s4} {icon.s5} {summary.rating.s5}{separator}
+{separator}
 ```
 
 Output:
@@ -112,11 +112,11 @@ total:50 avg:3.92
 #### entry
 Default template:
 ```
-{entry.title} by {entry.author}{sepalator}
-{entry.rating.icon}{sepalator}
-{entry.comment}{sepalator}
-{entry.updated} {entry.version}{sepalator}
-{sepalator}
+{entry.title} by {entry.author}{separator}
+{entry.rating.icon}{separator}
+{entry.comment}{separator}
+{entry.updated} {entry.version}{separator}
+{separator}
 ```
 
 Output:

--- a/examples/hyperlapse.js
+++ b/examples/hyperlapse.js
@@ -7,8 +7,8 @@ iTunesAppReviews.on('data', function(review) {
   // custom template
   var options = {
     template: {
-      header: '{title} total: {summary.total}{sepalator}',
-      entry: '{entry.rating.icon} by {entry.author}{sepalator}'
+      header: '{title} total: {summary.total}{separator}',
+      entry: '{entry.rating.icon} by {entry.author}{separator}'
     }
   };
   console.log(iTunesAppReviews.report(review, options));

--- a/lib/itunes-app-reviews.js
+++ b/lib/itunes-app-reviews.js
@@ -25,7 +25,7 @@ ITunesAppReview.prototype.getReviews = function(appId, country, limit) {
   country = country || 'us';
   limit = limit || 1;
   var self = this;
-  
+
 	async.times(limit, function(n, next) {
 		var num = ++n;
 		doRequest(num, function(err, data) {
@@ -40,7 +40,7 @@ ITunesAppReview.prototype.getReviews = function(appId, country, limit) {
 			self.emit('data', flat);
 		}
 	});
-  
+
   function doRequest(page, callback) {
     // get xml data, because json data is incomplete
   	var url = 'https://itunes.apple.com/' + country + '/rss/customerreviews/page=';
@@ -135,13 +135,13 @@ ITunesAppReview.prototype.summarize = function(data) {
  * report reviews
  * @param {array} reviews data (Required)
  * @param {object} options
- * @param {string} options.sepalator, default: '\n'
+ * @param {string} options.separator, default: '\n'
  * @param {srring} options.day
  * @param {object} options.template
  * @param {object} options.template.header header template, you can use those variables below.
- * {title}, {day}, {sepalator}, {icon.s1} to {icon.s5}, {summary.total}, {summary.average}, {summary.rating.s1} to {summary.rating.s5}
+ * {title}, {day}, {separator}, {icon.s1} to {icon.s5}, {summary.total}, {summary.average}, {summary.rating.s1} to {summary.rating.s5}
  * @param {object} options.template.entry entry template, you can use those variables below.
- * {entry.title}, {entry.author}, {sepalator}, {entry.rating.icon}, {entry.comment}, {entry.updated}, {entry.version}
+ * {entry.title}, {entry.author}, {separator}, {entry.rating.icon}, {entry.comment}, {entry.updated}, {entry.version}
  * @return {object} summary data, it includes rating, total, average
 **/
 ITunesAppReview.prototype.report = function(data, options) {
@@ -149,26 +149,27 @@ ITunesAppReview.prototype.report = function(data, options) {
   options = options || {};
   var self = this;
   var summaryData = self.summarize(data);
-  var sepalator = options.sepalator || '\n';
+  var separator = options.separator || options.sepalator || '\n'; // Leave the "sepalator" option for the compatibility due to my typo
   var day = options.day || '';
   var defaultTemplate = {};
-  defaultTemplate.header = '{title} {day}{sepalator}';
-  defaultTemplate.header += 'total:{summary.total} avg:{summary.average}{sepalator}';
-  defaultTemplate.header += '{icon.s1} {summary.rating.s1} {icon.s2} {summary.rating.s2} {icon.s3} {summary.rating.s3} {icon.s4} {summary.rating.s4} {icon.s5} {summary.rating.s5}{sepalator}{sepalator}';  
-  defaultTemplate.entry = '{entry.title} by {entry.author}{sepalator}';
-  defaultTemplate.entry += '{entry.rating.icon}{sepalator}';
-  defaultTemplate.entry += '{entry.comment}{sepalator}';
-  defaultTemplate.entry += '{entry.updated} {entry.version}{sepalator}{sepalator}';
+  defaultTemplate.header = '{title} {day}{separator}';
+  defaultTemplate.header += 'total:{summary.total} avg:{summary.average}{separator}';
+  defaultTemplate.header += '{icon.s1} {summary.rating.s1} {icon.s2} {summary.rating.s2} {icon.s3} {summary.rating.s3} {icon.s4} {summary.rating.s4} {icon.s5} {summary.rating.s5}{separator}{separator}';
+  defaultTemplate.entry = '{entry.title} by {entry.author}{separator}';
+  defaultTemplate.entry += '{entry.rating.icon}{separator}';
+  defaultTemplate.entry += '{entry.comment}{separator}';
+  defaultTemplate.entry += '{entry.updated} {entry.version}{separator}{separator}';
   var template = options.template || defaultTemplate;
   var reviewData = {
     title: 'iTunes Review Report',
     day: day,
     icon: { s1: '★', s2: '★★', s3: '★★★', s4: '★★★★', s5: '★★★★★' },
     summary: summaryData,
-    sepalator: sepalator
+    separator: separator,
+    sepalator: separator // Leave the "sepalator" option for the compatibility due to my typo
   };
   var text = '';
-  
+
   // insert header data
   text = interpolate(template.header, reviewData);
 
@@ -187,7 +188,8 @@ ITunesAppReview.prototype.report = function(data, options) {
         updated: dateformat(entry.updated[0], 'yyyy-mm-dd h:MM:ss TT'),
         version: 'v' + entry['im:version'][0]
       },
-      sepalator: sepalator
+      separator: separator,
+      sepalator: separator // Leave the "sepalator" option for the compatibility due to my typo
     };
     contentText += interpolate(template.entry, entryData);
   });
@@ -195,7 +197,7 @@ ITunesAppReview.prototype.report = function(data, options) {
   // remove unused variables
   text += contentText;
   text = text.replace(/{[\w\.\-_]+}/g, '');
-  
+
 	return text;
 };
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "assert": "^1.3.0",
     "gulp": "^3.8.10",
-    "gulp-jshint": "^1.9.0",
-    "lodash": "^3.0.0"
+    "gulp-jshint": "^1.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itunes-app-reviews",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Get the user reviews from iTunes Store.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ describe('filterByDate()', function() {
     ];
     assert.deepEqual(itunesAppReviews.filterByDate(data, '2015-01-26'), expected);
   });
-  
+
   it('should return false when the data params is not array', function () {
     assert.equal(itunesAppReviews.filterByDate({}), false);
   });
@@ -45,7 +45,7 @@ describe('filterByVersion()', function() {
     ];
     assert.deepEqual(itunesAppReviews.filterByVersion(data, '5.0.0'), expected);
   });
-  
+
   it('should return false when the data params is not array', function () {
     assert.equal(itunesAppReviews.filterByVersion({}), false);
   });
@@ -80,7 +80,7 @@ describe('summarize()', function() {
     };
     assert.deepEqual(itunesAppReviews.summarize(data), expected);
   });
-  
+
   it('should return false when the data params is not array', function () {
     assert.equal(itunesAppReviews.summarize({}), false);
   });
@@ -105,13 +105,13 @@ describe('report()', function() {
     var expected = 'iTunes Review Report  \n ★ ★★ ★★★ ★★★★ ★★★★★';
     var options = {
       template: {
-        header: '{title} {day} {sepalator} {icon.s1} {icon.s2} {icon.s3} {icon.s4} {icon.s5}',
+        header: '{title} {day} {separator} {icon.s1} {icon.s2} {icon.s3} {icon.s4} {icon.s5}',
         entry: ''
       }
     };
     assert.deepEqual(itunesAppReviews.report(data, options), expected);
   });
-  
+
   it('should get report customized header 2', function () {
     var expected = '1 5 0 0 0 0 1';
     var options = {
@@ -122,18 +122,18 @@ describe('report()', function() {
     };
     assert.deepEqual(itunesAppReviews.report(data, options), expected);
   });
-  
+
   it('should get report customized entry', function () {
     var expected = 'title author \n ★★★★★ comment 2015-01-28 9:00:00 AM v5.0.1';
     var options = {
       template: {
         header: '',
-        entry: '{entry.title} {entry.author} {sepalator} {entry.rating.icon} {entry.comment} {entry.updated} {entry.version}'
+        entry: '{entry.title} {entry.author} {separator} {entry.rating.icon} {entry.comment} {entry.updated} {entry.version}'
       }
     };
     assert.deepEqual(itunesAppReviews.report(data, options), expected);
   });
-  
+
   it('should get report inserted day string', function () {
     var expected = 'iTunes Review Report 2015-01-28';
     var options = {
@@ -145,8 +145,20 @@ describe('report()', function() {
     };
     assert.deepEqual(itunesAppReviews.report(data, options), expected);
   });
-  
-  it('should get report, sepalator is <br>', function () {
+
+  it('should get report, separator is <br>', function () {
+    var expected = 'iTunes Review Report<br>';
+    var options = {
+      separator: '<br>',
+      template: {
+        header: '{title}{separator}',
+        entry: ''
+      }
+    };
+    assert.deepEqual(itunesAppReviews.report(data, options), expected);
+  });
+
+  it('should get report, sepalator is <br> (Leave the "sepalator" option for the compatibility due to my typo).', function () {
     var expected = 'iTunes Review Report<br>';
     var options = {
       sepalator: '<br>',
@@ -155,10 +167,9 @@ describe('report()', function() {
         entry: ''
       }
     };
-    console.log(itunesAppReviews.report(data, options))
     assert.deepEqual(itunesAppReviews.report(data, options), expected);
   });
-  
+
   it('should return false when the data params is not array', function () {
     assert.equal(itunesAppReviews.report({}), false);
   });


### PR DESCRIPTION
- Fix typo, and change the separator option's key name (it's compatible with the previous version)
- Remove an unnecessary devDependencies
- Update version
